### PR TITLE
[new]: No pay hours calculation part + updated the overtime and lateminute payments calculating methods

### DIFF
--- a/src/main/java/com/hris/HRIS/service/PayrollReportsGenerationService.java
+++ b/src/main/java/com/hris/HRIS/service/PayrollReportsGenerationService.java
@@ -52,9 +52,14 @@ public class PayrollReportsGenerationService {
             payitem.setVariable("description", payItemModel.getDescription());
             payitem.setVariable("amount", employeePayItemsList.get(i).getAmount());
 
-            amount += employeePayItemsList.get(i).getAmount();
-
-            payitems.add(payitem);
+            if(payItemModel.getItemType().equals("Deletion")){
+                deductedAmount += employeePayItemsList.get(i).getAmount();
+                deductions.add(payitem);
+            }else{
+                amount += employeePayItemsList.get(i).getAmount();
+                payitems.add(payitem);
+            }
+            
         }
 
         double taxRate = Double.parseDouble(taxController.getTaxRateForSalary(amount - deductedAmount).getBody().getMessage());


### PR DESCRIPTION
#### Updated endpoints:
> /api/v1/employee/payitems/{email}/overtime-payment/{totalHoursAllowed}/{overtimeHoursWorked}
- Changed to : /api/v1/employee/payitems/{email}/overtime-payment

Request body:
```
{
    "totalHoursAllowed" : 240,
    "overtimeHoursWorked" : 0.0
}
```
#### New endpoints:
/api/v1/employee/payitems/{email}/late-min-deduction

Request body:
```
{
    "totalHoursAllowed" : 240,
    "lateMinutes" : 0.0
}
```

/api/v1/employee/payitems/{email}/nopay-hours-deduction

Request body:
```
{
    "totalHoursAllowed" : 240,
    "noPayHours" : 0.0
}
```

#### Return messages through the above endpoints:
```
{
    "message": "[pay-item] updated successfully."
}
```
```
{
    "message": "[...hours...] are out of range."
}
```
```
{
    "message": "Failed to process the received parameters."
}
```